### PR TITLE
Test cases for hanami/hanami#528

### DIFF
--- a/test/fixtures/exception_handler/application.rb
+++ b/test/fixtures/exception_handler/application.rb
@@ -1,0 +1,13 @@
+module ExceptionHandler
+  class Application < Hanami::Application
+    configure do
+      routes do
+        get '/controller_exception', to: 'exceptional_home#controller_exception'
+        get '/view_exception', to: 'exceptional_home#view_exception'
+        get '/no_exception', to: 'exceptional_home#no_exception'
+      end
+    end
+
+    load!
+  end
+end

--- a/test/fixtures/exception_handler/base.rb
+++ b/test/fixtures/exception_handler/base.rb
@@ -1,0 +1,4 @@
+require_relative 'errors'
+require_relative 'controllers'
+require_relative 'views'
+require_relative 'application'

--- a/test/fixtures/exception_handler/controllers.rb
+++ b/test/fixtures/exception_handler/controllers.rb
@@ -1,0 +1,28 @@
+module ExceptionHandler
+  module Controllers
+    module ExceptionalHome
+      class ControllerException
+        include Hanami::Action
+
+        def call(_params)
+          fail Errors::ControllerError
+        end
+      end
+
+      class ViewException
+        include Hanami::Action
+
+        def call(_params); end
+      end
+
+      class NoException
+        include Hanami::Action
+
+        def call(_params)
+          self.body = 'okay, you passed'
+          self.status = 200
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures/exception_handler/errors.rb
+++ b/test/fixtures/exception_handler/errors.rb
@@ -1,0 +1,7 @@
+module ExceptionHandler
+  module Errors
+    class Base < ::StandardError; end
+    class ControllerError < Base; end
+    class ViewError < Base; end
+  end
+end

--- a/test/fixtures/exception_handler/views.rb
+++ b/test/fixtures/exception_handler/views.rb
@@ -1,0 +1,13 @@
+module ExceptionHandler
+  module Views
+    module ExceptionalHome
+      class ViewException
+        include Hanami::View
+
+        def render
+          fail Errors::ViewError
+        end
+      end
+    end
+  end
+end

--- a/test/integration/exception_handler_test.rb
+++ b/test/integration/exception_handler_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+require 'rack/test'
+require 'fixtures/exception_handler/base'
+
+describe 'Exception handler' do
+  include Rack::Test::Methods
+
+  let(:app) { ExceptionHandler::Application.new }
+
+  describe 'rack.exception Rack variable' do
+    let(:subject) { last_request.env['rack.exception'] }
+
+    describe 'controller exception' do
+      before { get '/controller_exception' }
+
+      it 'sets the variable' do
+        subject.must_be_kind_of ExceptionHandler::Errors::ControllerError
+      end
+    end
+
+    describe 'view exception' do
+      it 'sets the variable' do
+        -> { get '/view_exception' }.must_raise ExceptionHandler::Errors::ViewError
+        subject.must_be_kind_of ExceptionHandler::Errors::ViewError
+      end
+    end
+
+    describe 'no exception' do
+      before { get '/no_exception' }
+
+      it 'does not set the variable' do
+        subject.must_be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit introduces test cases for previously created error-handling
spike. The interesting part is that controller exception handler does
not re-raise exception while aforementioned spike does. This might bring
some inconsistency.
